### PR TITLE
Created Default Request Listener if none specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 npm-*
 *.js.map
+yarn.lock

--- a/source/api.d.ts
+++ b/source/api.d.ts
@@ -1,11 +1,16 @@
+/// <reference types="express" />
 import * as express from "express";
-import { Method, Request, RequestListener } from "./types";
+import { Method, Request, PromiseOrVoid, RequestListener, SimpleResponse } from "./types";
 export declare type Promise_Or_Void = Promise<void> | void;
 export declare type Request_Processor = (request: Request) => Promise<Request>;
 export declare type Response_Generator = (request: Request) => Promise<any>;
 export declare type Filter = (request: Request) => Promise_Or_Void;
 export declare type Validator = (data: any) => boolean;
 export declare function logErrorToConsole(error: any): void;
+export declare class DefaultRequestListener implements RequestListener {
+    onRequest(request: Request, response: SimpleResponse, res: any): PromiseOrVoid;
+    onError(error: any, request?: Request): PromiseOrVoid;
+}
 export interface Endpoint_Info {
     method: Method;
     path: string;

--- a/source/api.js
+++ b/source/api.js
@@ -29,6 +29,7 @@ var DefaultRequestListener = (function () {
     };
     return DefaultRequestListener;
 }());
+exports.DefaultRequestListener = DefaultRequestListener;
 // This function is currently modifying req.body for performance though could be changed if it ever caused problems.
 function get_arguments(req) {
     var result = req.body || {};

--- a/source/api.ts
+++ b/source/api.ts
@@ -24,7 +24,7 @@ export function logErrorToConsole(error) {
     console.error("Error", error.status, error.stack)
 }
 
-class DefaultRequestListener implements RequestListener {
+export class DefaultRequestListener implements RequestListener {
 
   onRequest(request: Request, response: SimpleResponse, res): PromiseOrVoid {
     return

--- a/source/errors.js
+++ b/source/errors.js
@@ -1,5 +1,5 @@
-// Lawn will handle any type of thrown errors, but also provides these helper Error types.
 "use strict";
+// Lawn will handle any type of thrown errors, but also provides these helper Error types.
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
         ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||

--- a/source/server.d.ts
+++ b/source/server.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="express" />
 import * as express from "express";
 import { Request_Processor } from "./api";
 import { RequestListener } from "./types";

--- a/source/server.js
+++ b/source/server.js
@@ -5,7 +5,7 @@ var api_1 = require("./api");
 var Server = (function () {
     function Server(default_preprocessor, requestedListener) {
         if (default_preprocessor === void 0) { default_preprocessor = null; }
-        if (requestedListener === void 0) { requestedListener = null; }
+        if (requestedListener === void 0) { requestedListener = new api_1.DefaultRequestListener(); }
         this.port = 3000;
         this.default_preprocessor = null;
         this.ajv = null;

--- a/source/server.ts
+++ b/source/server.ts
@@ -1,5 +1,5 @@
 import * as express from "express"
-import {create_endpoints, Request_Processor} from "./api"
+import {create_endpoints, DefaultRequestListener, Request_Processor} from "./api"
 import {RequestListener} from "./types";
 
 export interface SSLConfig {
@@ -21,7 +21,7 @@ export class Server {
   private ajv = null
   private requestListener: RequestListener
 
-  constructor(default_preprocessor: Request_Processor = null, requestedListener: RequestListener = null) {
+  constructor(default_preprocessor: Request_Processor = null, requestedListener: RequestListener = new DefaultRequestListener()) {
     this.app = express()
     this.default_preprocessor = default_preprocessor
     this.requestListener = requestedListener


### PR DESCRIPTION
If a RequestListener is not specified in params, creates a default one. Exports DefaultRequestListener to accomplish this. Currenty lawn will throw an error while processing any request without this listener. This fix is for anyone who is using lawn but not using village to initalize their lawn server. Also adds yarn.lock to gitignore.